### PR TITLE
Working SPI output of keys

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "C_Cpp.errorSquiggles": "Disabled"
+}

--- a/keyboards/bluerabbit/wkb60/config.h
+++ b/keyboards/bluerabbit/wkb60/config.h
@@ -63,7 +63,7 @@
 
 
 
-
+#define USE_SPI         
 #define SPI_DRIVER      SPID1
 #define SPI_SCK_PIN     A5
 #define SPI_MOSI_PIN    A7

--- a/keyboards/bluerabbit/wkb60/config.h
+++ b/keyboards/bluerabbit/wkb60/config.h
@@ -60,3 +60,11 @@
 /* Locking resynchronize hack */
 #define LOCKING_RESYNC_ENABLE
 
+
+
+
+
+#define SPI_DRIVER      SPID1
+#define SPI_SCK_PIN     A5
+#define SPI_MOSI_PIN    A7
+#define SPI_MISO_PIN    A6

--- a/keyboards/bluerabbit/wkb60/halconf.h
+++ b/keyboards/bluerabbit/wkb60/halconf.h
@@ -156,7 +156,7 @@
  * @brief   Enables the SPI subsystem.
  */
 #if !defined(HAL_USE_SPI) || defined(__DOXYGEN__)
-#define HAL_USE_SPI                         FALSE
+#define HAL_USE_SPI                         TRUE
 #endif
 
 /**

--- a/keyboards/bluerabbit/wkb60/mcuconf.h
+++ b/keyboards/bluerabbit/wkb60/mcuconf.h
@@ -192,7 +192,7 @@
 /*
  * SPI driver system settings.
  */
-#define STM32_SPI_USE_SPI1                  FALSE
+#define STM32_SPI_USE_SPI1                  TRUE
 #define STM32_SPI_USE_SPI2                  FALSE
 #define STM32_SPI_USE_SPI3                  FALSE
 #define STM32_SPI_SPI1_RX_DMA_STREAM        STM32_DMA_STREAM_ID(2, 0)

--- a/keyboards/bluerabbit/wkb60/rules.mk
+++ b/keyboards/bluerabbit/wkb60/rules.mk
@@ -53,3 +53,10 @@ HD44780_ENABLE = no         # Enable support for HD44780 based LCDs (+400)
 
 LAYOUTS = ortho_1x1
 
+SRC =	drivers/chibios/spi_master.c
+		
+		
+		
+		
+
+

--- a/keyboards/bluerabbit/wkb60/wkb60.c
+++ b/keyboards/bluerabbit/wkb60/wkb60.c
@@ -1,6 +1,31 @@
 #include "spi_master.h"
+#include "print.h"
+
 #include "wkb60.h"
+
+#define SS_PIN A4
+
+union Keycode_wireless {
+    uint16_t kc;
+    uint8_t bytes[2]; 
+} kcw;
 
 void keyboard_pre_init_kb(void) {
     spi_init();
+}
+
+bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
+	// put your per-action keyboard code here
+	// runs for every action, just before processing by the firmware
+    kcw.kc = keycode;
+   
+    spi_start(SS_PIN, false, 0, 12);
+    spi_transmit(kcw.bytes,sizeof(kcw.bytes));
+    spi_stop();
+
+	return process_record_user(keycode, record);
+}
+
+void keyboard_post_init_user(void) {
+  debug_enable=true;
 }

--- a/keyboards/bluerabbit/wkb60/wkb60.c
+++ b/keyboards/bluerabbit/wkb60/wkb60.c
@@ -3,12 +3,19 @@
 
 #include "wkb60.h"
 
-#define SS_PIN A4
+#define BLE_SS_PIN A4
 
 union Keycode_wireless {
     uint16_t kc;
     uint8_t bytes[2]; 
 } kcw;
+
+
+void transmit_to_ble(uint8_t *keycode){
+    spi_start(BLE_SS_PIN, false, 0, 12);
+    spi_transmit(kcw.bytes,sizeof(kcw.bytes));
+    spi_stop();
+}
 
 void keyboard_pre_init_kb(void) {
     spi_init();
@@ -17,11 +24,12 @@ void keyboard_pre_init_kb(void) {
 bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
 	// put your per-action keyboard code here
 	// runs for every action, just before processing by the firmware
-    kcw.kc = keycode;
-   
-    spi_start(SS_PIN, false, 0, 12);
-    spi_transmit(kcw.bytes,sizeof(kcw.bytes));
-    spi_stop();
+    // kcw.kc = keycode;
+    // transmit_to_ble(keycode);
+
+    if (record->event.pressed){
+        transmit_to_ble(kcw.bytes);
+    }
 
 	return process_record_user(keycode, record);
 }

--- a/keyboards/bluerabbit/wkb60/wkb60.c
+++ b/keyboards/bluerabbit/wkb60/wkb60.c
@@ -1,1 +1,6 @@
+#include "spi_master.h"
 #include "wkb60.h"
+
+void keyboard_pre_init_kb(void) {
+    spi_init();
+}

--- a/keyboards/bluerabbit/wkb60/wkb60.c
+++ b/keyboards/bluerabbit/wkb60/wkb60.c
@@ -1,5 +1,6 @@
 #include "spi_master.h"
 #include "print.h"
+#include <string.h>
 
 #include "wkb60.h"
 
@@ -24,10 +25,12 @@ void keyboard_pre_init_kb(void) {
 bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
 	// put your per-action keyboard code here
 	// runs for every action, just before processing by the firmware
-    // kcw.kc = keycode;
-    // transmit_to_ble(keycode);
+    kcw.kc = keycode;
 
     if (record->event.pressed){
+        transmit_to_ble(kcw.bytes);
+    } else {
+        memset(kcw.bytes, 0, sizeof(kcw.bytes));
         transmit_to_ble(kcw.bytes);
     }
 


### PR DESCRIPTION
STM32F401 SPI setup
Working SPI output on process_keys_kb in wkb60.c where the keycode is output over SPI on both keypress down and keypress up. 
This works with the BL device.